### PR TITLE
separator fix for not removing entire line if there's more data present

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ of inactivity on the socket.
 * `irs`: Input record separator. A separator used to distinguish between lines of the response. Defaults to '\r\n'.
 * `ors`: Output record separator. A separator used to execute commands (break lines on input). Defaults to '\n'.
 * `echoLines`: The number of lines used to cut off the response. Defaults to 1.
-* `pageSeparator`: The pattern used to break the number of lines on output. Defaults to '---- More'.
+* `pageSeparator`: The pattern used (and removed from final output) for breaking the number of lines on output. Defaults to '---- More'.
 
 ### connection.exec(data, [options], [callback])
 

--- a/lib/telnet-client.js
+++ b/lib/telnet-client.js
@@ -164,8 +164,10 @@ function parseData(chunk, telnetObj) {
     telnetObj.cmdOutput = telnetObj.stringData.split(telnetObj.irs);
 
     for (var i = 0; i < telnetObj.cmdOutput.length; i++) {
-      if (telnetObj.cmdOutput[i].search(telnetObj.pageSeparator) !== -1)
-        telnetObj.cmdOutput.splice(i, 1);
+      if (telnetObj.cmdOutput[i].search(telnetObj.pageSeparator) !== -1) {
+        telnetObj.cmdOutput[i] = telnetObj.cmdOutput[i].replace(telnetObj.pageSeparator, '');
+        if (telnetObj.cmdOutput[i].length === 0) telnetObj.cmdOutput.splice(i, 1);
+      }
     }
 
     if (telnetObj.echoLines === 1) telnetObj.cmdOutput.shift();


### PR DESCRIPTION
The page separator was removing data from my telnet output, this fixed it.