### PR TITLE
Add support for explicit detection of failed logins

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ of inactivity on the socket.
 * `shellPrompt`: Shell prompt that the host is using. Defaults to regex '/(?:\/ )?#\s/'.
 * `loginPrompt`: Username/login prompt that the host is using. Defaults to regex '/login[: ]*$/i'.
 * `passwordPrompt`: Username/login prompt that the host is using. Defaults to regex '/Password: /i'.
+* `loginFailedPrompt`: String or regex to match if your host provides login failure messages. Defaults to undefined.
 * `username`: Username used to login. Defaults to 'root'.
 * `password`: Username used to login. Defaults to 'guest'.
 * `irs`: Input record separator. A separator used to distinguish between lines of the response. Defaults to '\r\n'.
@@ -84,6 +85,7 @@ Options:
 
 * `shellPrompt`: Shell prompt that the host is using. Defaults to regex '/(?:\/ )?#\s/'.
 * `loginPrompt`: Username/login prompt that the host is using. Defaults to regex '/login[: ]*$/i'.
+* `loginFailedPrompt`: String or regex to match if your host provides login failure messages. Defaults to undefined.
 * `timeout`: Sets the socket to timeout after the specified number of milliseconds
 of inactivity on the socket.
 * `irs`: Input record separator. A separator used to distinguish between lines of the response. Defaults to '\r\n'.
@@ -115,6 +117,10 @@ Emitted when the write of given data is sent to the socket.
 
 Emitted if the socket times out from inactivity. This is only to notify that the socket has been idle.
 The user must manually close the connection.
+
+### Event: 'loginfailed'
+
+Emitted when the loginFailedPrompt pattern is provided and a match is found from the host. The 'destroy()' method is called directly following this event.
 
 ### Event: 'error'
 

--- a/lib/telnet-client.js
+++ b/lib/telnet-client.js
@@ -27,6 +27,8 @@ Telnet.prototype.connect = function(opts) {
     ? opts.loginPrompt : /login[: ]*$/i);
   this.passwordPrompt = (typeof opts.passwordPrompt !== 'undefined'
     ? opts.passwordPrompt : /Password: /i);
+  this.failedLoginPrompt = (typeof opts.failedLoginPrompt !== 'undefined'
+    ? opts.failedLoginPrompt : undefined);
   this.username = (typeof opts.username !== 'undefined' ? opts.username : 'root');
   this.password = (typeof opts.password !== 'undefined' ? opts.password : 'guest');
   this.irs = (typeof opts.irs !== 'undefined' ? opts.irs : '\r\n');
@@ -81,6 +83,7 @@ Telnet.prototype.exec = function(cmd, opts, callback) {
   else if (opts && opts instanceof Object) {
     self.shellPrompt = opts.shellPrompt || self.shellPrompt;
     self.loginPrompt = opts.loginPrompt || self.loginPrompt;
+    self.failedLoginPrompt = opts.failedLoginPrompt || self.failedLoginPrompt;
     self.timeout = opts.timeout || self.timeout;
     self.irs = opts.irs || self.irs;
     self.ors = opts.ors || self.ors;
@@ -145,6 +148,11 @@ function parseData(chunk, telnetObj) {
     else if (stringData.search(telnetObj.passwordPrompt) !== -1) {
       telnetObj.telnetState = 'login';
       login(telnetObj, 'password');
+    }
+    else if (typeof telnetObj.failedLoginPrompt !== 'undefined' && stringData.search(telnetObj.failedLoginPrompt) !== -1) {
+      telnetObj.telnetState = 'failedlogin';
+      telnetObj.emit('failedlogin', stringData);
+      telnetObj.destroy();
     }
     else return;
   }


### PR DESCRIPTION
There didn't seem to be an easy we to detect when the host was telling me my credentials were wrong, which let things hang around indefinitely without an obvious error.

This patch adds a new option `failedLoginPrompt` as well as emits a new event `failedlogin` to allow for more explicit/faster capture of bad credentials.

This is mainly useful if a host actually provides a failure message, and if it doesn't, then this is sort of worthless.  YMMV.

The only part I'm not sure about is how to properly clean up  -- currently I call destroy(), which might be a little too harsh.  Feel free to adjust as you see fit. =)