### PR TITLE
Proposed fix #37 - Continued retry of login.

### DIFF
--- a/lib/telnet-client.js
+++ b/lib/telnet-client.js
@@ -153,7 +153,12 @@ function parseData(chunk, telnetObj, callback) {
 
     var promptIndex = search(stringData, telnetObj.shellPrompt)
 
-    if (promptIndex !== -1) {
+    if (typeof telnetObj.failedLoginPrompt !== 'undefined' && search(stringData, telnetObj.failedLoginPrompt) !== -1) {
+      telnetObj.telnetState = 'failedlogin'
+      telnetObj.emit('failedlogin', stringData)
+      telnetObj.destroy()
+    }
+    else if (promptIndex !== -1) {
       telnetObj.shellPrompt = stringData.substring(promptIndex)
       telnetObj.telnetState = 'sendcmd'
       telnetObj.stringData = ''
@@ -168,11 +173,6 @@ function parseData(chunk, telnetObj, callback) {
     else if (search(stringData, telnetObj.passwordPrompt) !== -1) {
       telnetObj.telnetState = 'login'
       login(telnetObj, 'password')
-    }
-    else if (typeof telnetObj.failedLoginPrompt !== 'undefined' && search(stringData, telnetObj.failedLoginPrompt) !== -1) {
-      telnetObj.telnetState = 'failedlogin'
-      telnetObj.emit('failedlogin', stringData)
-      telnetObj.destroy()
     }
     else return
   }


### PR DESCRIPTION
A proposed fix to close #37.

Example Wireshark of failed attempt post-fix:
```
....................................
.[1mWelcome to CLI.[22m.[0m

.[1mLogin: .[22m.[0musername
username

.[1mPassword: .[22m.[0mpassword
       
Error : -24007 : Invalid user name or password.

.[1mLogin: .[22m.[0m
Logged out successfully
```

Successful login still works:
```
....................................
.[1mWelcome to CLI.[22m.[0m

.[1mLogin: .[22m.[0musername
username

.[1mPassword: .[22m.[0mtherightpassword

Warning: Unauthorized access to is prohibited.
.[1mSystem>.[22m.[0m
```