### PR TITLE
Add option to strip prompt from result.

### DIFF
--- a/lib/telnet-client.js
+++ b/lib/telnet-client.js
@@ -35,6 +35,7 @@ Telnet.prototype.connect = function(opts) {
     self.irs = (typeof opts.irs !== 'undefined' ? opts.irs : '\r\n')
     self.ors = (typeof opts.ors !== 'undefined' ? opts.ors : '\n')
     self.echoLines = (typeof opts.echoLines !== 'undefined' ? opts.echoLines : 1)
+    self.stripShellPrompt = (typeof opts.stripShellPrompt !== 'undefined' ? opts.stripShellPrompt : true)
     self.pageSeparator = (typeof opts.pageSeparator !== 'undefined'
       ? opts.pageSeparator : '---- More')
     self.response = ''
@@ -200,7 +201,7 @@ function parseData(chunk, telnetObj, callback) {
     else if (telnetObj.echoLines > 1) telnetObj.cmdOutput.splice(0, telnetObj.echoLines)
 
     // remove prompt
-    telnetObj.cmdOutput.pop()
+    if(telnetObj.stripShellPrompt) telnetObj.cmdOutput.pop()
 
     telnetObj.emit('responseready')
   }


### PR DESCRIPTION
Adding option to strip shell prompt permits knowing where at in shell for shells that don't support a 'pwd' type functionality.

Default added to remove conflicts for existing implementations.