### PR TITLE
fix prompt regex issue

### DIFF
--- a/lib/telnet-client.js
+++ b/lib/telnet-client.js
@@ -234,7 +234,7 @@ function parseData(chunk, telnetObj, callback) {
     var stringData = chunk.toString()
 
     telnetObj.stringData += stringData
-    promptIndex = telnetObj.stringData.indexOf(telnetObj.shellPrompt)
+    promptIndex = search(telnetObj.stringData, telnetObj.shellPrompt)
 
     if (promptIndex === -1 && stringData.length !== 0) {
       if (search(stringData, telnetObj.pageSeparator) !== -1) {


### PR DESCRIPTION
Hi, I've faced some issues after upgrading to the latest version of your module. After some debugging I realized that it didn't recognize the prompt.

Apparently you've already created the `search` function that could work with both regex and string, but forgot to use it when parsing a response. 

At least this fix resolved the issues I had.

Hope it helped. Thanks for you work.