### PR TITLE
use Buffer.from instead of Buffer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -251,7 +251,7 @@ function parseData(chunk, telnetObj, callback) {
 
     if (promptIndex === -1 && stringData.length !== 0) {
       if (search(stringData, telnetObj.pageSeparator) !== -1) {
-        telnetObj.telnetSocket.write(Buffer('20', 'hex'))
+        telnetObj.telnetSocket.write(Buffer.from('20', 'hex'))
       }
 
       return
@@ -306,7 +306,7 @@ function negotiate(socket, chunk) {
 
   negResp = negData.toString('hex').replace(/fd/g, 'fc').replace(/fb/g, 'fd')
 
-  if (socket.writable) socket.write(Buffer(negResp, 'hex'))
+  if (socket.writable) socket.write(Buffer.from(negResp, 'hex'))
 
   if (cmdData != undefined) return cmdData
   else return


### PR DESCRIPTION
Let's use ```Buffer.from``` instead of ```Buffer``` beacuse  at latest release we get following warning:
```(node:8076) DeprecationWarning: Using Buffer without `new` will soon stop working. Use `new Buffer()`, or preferably `Buffer.from()`, `Buffer.allocUnsafe()` or `Buffer.alloc()` instead.```