### PR TITLE
Fixed infinite loop in case of failed login

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,7 @@ module.exports = class Telnet extends events.EventEmitter {
       this.loginPrompt = (typeof opts.loginPrompt !== 'undefined' ? opts.loginPrompt : /login[: ]*$/i)
       this.passwordPrompt = (typeof opts.passwordPrompt !== 'undefined' ? opts.passwordPrompt : /Password: /i)
       this.failedLoginMatch = opts.failedLoginMatch
+      this.loginPromptReceived = false
 
       this.debug = (typeof opts.debug !== 'undefined' ? opts.debug : false)
       this.username = (typeof opts.username !== 'undefined' ? opts.username : 'root')
@@ -210,7 +211,22 @@ module.exports = class Telnet extends events.EventEmitter {
 
       var promptIndex = utils.search(stringData, this.shellPrompt)
 
-      if (typeof this.failedLoginMatch !== 'undefined' && utils.search(stringData, this.failedLoginMatch) !== -1) {
+      if (utils.search(stringData, this.loginPrompt) !== -1) {
+        // make sure we don't end up in an infinite loop
+        if (!this.loginPromptReceived) { 
+          this.telnetState = 'login'
+          this._login('username')
+          this.loginPromptReceived = true;
+        } else {
+          this.emit('failedlogin', stringData)
+          this.destroy()
+        }
+      }
+      else if (utils.search(stringData, this.passwordPrompt) !== -1) {
+        this.telnetState = 'login'
+        this._login('password')
+      }
+      else if (typeof this.failedLoginMatch !== 'undefined' && utils.search(stringData, this.failedLoginMatch) !== -1) {
         this.telnetState = 'failedlogin'
 
         this.emit('failedlogin', stringData)
@@ -220,19 +236,13 @@ module.exports = class Telnet extends events.EventEmitter {
         this.shellPrompt = stringData.substring(promptIndex)
         this.telnetState = 'standby'
         this.stringData = ''
+        this.loginPromptReceived = false;
 
         this.emit('ready', this.shellPrompt)
 
         if (callback) callback('ready', this.shellPrompt)
       }
-      else if (utils.search(stringData, this.loginPrompt) !== -1) {
-        this.telnetState = 'login'
-        this._login('username')
-      }
-      else if (utils.search(stringData, this.passwordPrompt) !== -1) {
-        this.telnetState = 'login'
-        this._login('password')
-      }
+
       else return
     }
     else if (this.telnetState === 'response') {


### PR DESCRIPTION
This patch should fix the infinite loop that occurs in case a wrong password has been supplied and there is no custom failed-login prompt.