### PR TITLE
Have the data event emit on response, not standby

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,7 +80,7 @@ module.exports = class Telnet extends events.EventEmitter {
       })
 
       this.socket.on('data', data => {
-        if (this.state === 'standby')
+        if (this.state === 'response')
           return this.emit('data', data)
 
         this._parseData(data, (event, parsed) => {


### PR DESCRIPTION
After debugging the project it seems that the live response data is coming in while the socket is in the "response" state. Therefore the data event should be emitted when the state is response. 

This seemed to fix my issue. If this has unforeseen consequences, let me know. 

Thanks. 