### PR TITLE
Add support for RegExp in sends opt.waitfor

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Sends data on the socket without requiring telnet negotiations.
 Options:
 
 * `ors`: Output record separator. A separator used to execute commands (break lines on input). Defaults to '\n'.
-* `waitfor`: Wait for the given string before returning a response. If not defined, the timeout value will be used.
+* `waitfor`: Wait for the given string or RegExp before returning a response. If not defined, the timeout value will be used.
 * `timeout`: A timeout used to wait for a server reply when the 'send' method is used. Defaults to 2000 (ms) or to sendTimeout ('connect' method) if set.
 * `maxBufferLength`: Maximum buffer length in bytes which can be filled with response data. Defaults to 1M.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -197,6 +197,7 @@ module.exports = class Telnet extends events.EventEmitter {
         this.ors = opts.ors || this.ors
         this.sendTimeout = opts.timeout || this.sendTimeout
         this.maxBufferLength = opts.maxBufferLength || this.maxBufferLength
+        this.waitfor = (opts.waitfor ? (opts.waitfor instanceof RegExp ? opts.waitfor : RegExp(opts.waitfor)) : false);
 
         data += this.ors
       }
@@ -208,7 +209,7 @@ module.exports = class Telnet extends events.EventEmitter {
 
           this.on('data', sendHandler)
 
-          if ((opts && opts.waitfor === undefined) || !opts) {
+          if (!self.waitfor || !opts) {
             setTimeout(() => {
               if (response === '') {
                   this.removeListener('data', sendHandler)
@@ -226,8 +227,8 @@ module.exports = class Telnet extends events.EventEmitter {
           function sendHandler(data) {
             response += data.toString()
 
-            if (opts && opts.waitfor !== undefined) {
-              if (!response.includes(opts.waitfor)) return
+            if (self.waitfor) {
+              if (!self.waitfor.test(response)) return
 
               self.removeListener('data', sendHandler)
               resolve(response)

--- a/lib/index.js
+++ b/lib/index.js
@@ -209,7 +209,7 @@ module.exports = class Telnet extends events.EventEmitter {
 
           this.on('data', sendHandler)
 
-          if (!self.waitfor || !opts) {
+          if (!this.waitfor || !opts) {
             setTimeout(() => {
               if (response === '') {
                   this.removeListener('data', sendHandler)


### PR DESCRIPTION
This would allow searching for specific patterns in a response if a static string is not known in advance.