### PR TITLE
Only emit error if there's a listener

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,10 +73,13 @@ module.exports = class Telnet extends events.EventEmitter {
       this.socket.setTimeout(this.timeout, () => {
         if (this.socket._connecting === true) {
           /* if cannot connect, emit error and destroy */
-          this.emit('error', 'Cannot connect')
+          if (this.listeners('error').length > 0)
+            this.emit('error', 'Cannot connect')
           this.socket.destroy()
+          return reject(new Error('Cannot connect'))
         }
-        else this.emit('timeout')
+        this.emit('timeout')
+        return reject(new Error('timeout'))
       })
 
       this.socket.on('data', data => {
@@ -91,7 +94,8 @@ module.exports = class Telnet extends events.EventEmitter {
       })
 
       this.socket.on('error', error => {
-        this.emit('error', error)
+        if (this.listeners('error').length > 0)
+          this.emit('error', error)
       })
 
       this.socket.on('end', () => {


### PR DESCRIPTION
Fix for #121 - doesn't seem to be a good way to mix Promises and EventEmitter.  Settled on only emitting if there's a listener.  This allows promises to work even if the connection fails.