### PR TITLE
Remove unnecessary else statement in index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -289,9 +289,6 @@ module.exports = class Telnet extends events.EventEmitter {
           this.state = 'login'
           this._login('username')
           this.loginPromptReceived = true
-        } else {
-          this.emit('failedlogin', stringData)
-          this.destroy()
         }
       }
       else if (utils.search(stringData, this.passwordPrompt) !== -1) {


### PR DESCRIPTION
If server is busy, login will unnecessarily fail due to unnecessarily emitting 'failedLogin' and destroy(). When I remove this else statement, the logins succeed and proceed as normal.

Resolves issue #129