### PR TITLE
Fixing partial response deadlock

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -152,7 +152,7 @@ module.exports = class Telnet extends events.EventEmitter {
             this.removeListener('responseready', responseHandler)
             this.removeListener('bufferexceeded', buffExcHandler)
 
-            if (!this.response) return reject(new Error('response not received'))
+            reject(new Error('response not received'))
           }, this.execTimeout)
         }
 


### PR DESCRIPTION
When timeout fires we need to reject the promise even when partial response is received because otherwise it will never be rejected or resolved after responseready is removed from the event listeners.