### PR TITLE
Improving connect promise handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ module.exports = class Telnet extends events.EventEmitter {
   }
 
   connect(opts) {
-    let promise;
+    let promise
     return promise = new Promise((resolve, reject) => {
       const host = (typeof opts.host !== 'undefined' ? opts.host : '127.0.0.1')
       const port = (typeof opts.port !== 'undefined' ? opts.port : 23)
@@ -89,9 +89,8 @@ module.exports = class Telnet extends events.EventEmitter {
           return this.emit('data', data)
 
         this._parseData(data, (event, parsed) => {
-          if (event === 'ready') {
-            if (promise.isPending())
-              resolve(parsed)
+          if (promise.isPending() && event === 'ready') {
+            resolve(parsed)
           }
         })
       })
@@ -99,20 +98,23 @@ module.exports = class Telnet extends events.EventEmitter {
       this.socket.on('error', error => {
         if (this.listeners('error').length > 0)
           this.emit('error', error)
+
         if (promise.isPending())
           reject(error)
       })
 
       this.socket.on('end', () => {
         this.emit('end')
+
         if (promise.isPending())
-          reject(new Error('socket ends'))
+          reject(new Error('Socket ends'))
       })
 
       this.socket.on('close', () => {
         this.emit('close')
+
         if (promise.isPending())
-          reject(new Error('socket closes'))
+          reject(new Error('Socket closes'))
       })
     })
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,8 @@ module.exports = class Telnet extends events.EventEmitter {
   }
 
   connect(opts) {
-    return new Promise((resolve, reject) => {
+    let promise;
+    return promise = new Promise((resolve, reject) => {
       const host = (typeof opts.host !== 'undefined' ? opts.host : '127.0.0.1')
       const port = (typeof opts.port !== 'undefined' ? opts.port : 23)
       this.timeout = (typeof opts.timeout !== 'undefined' ? opts.timeout : 500)
@@ -71,7 +72,7 @@ module.exports = class Telnet extends events.EventEmitter {
       this.inputBuffer = ''
 
       this.socket.setTimeout(this.timeout, () => {
-        if (this.socket._connecting === true) {
+        if (promise.isPending()) {
           /* if cannot connect, emit error and destroy */
           if (this.listeners('error').length > 0)
             this.emit('error', 'Cannot connect')
@@ -89,7 +90,8 @@ module.exports = class Telnet extends events.EventEmitter {
 
         this._parseData(data, (event, parsed) => {
           if (event === 'ready') {
-            resolve(parsed)
+            if (promise.isPending())
+              resolve(parsed)
           }
         })
       })
@@ -97,15 +99,20 @@ module.exports = class Telnet extends events.EventEmitter {
       this.socket.on('error', error => {
         if (this.listeners('error').length > 0)
           this.emit('error', error)
+        if (promise.isPending())
           reject(error)
       })
 
       this.socket.on('end', () => {
         this.emit('end')
+        if (promise.isPending())
+          reject(new Error('socket ends'))
       })
 
       this.socket.on('close', () => {
         this.emit('close')
+        if (promise.isPending())
+          reject(new Error('socket closes'))
       })
     })
   }


### PR DESCRIPTION
A buggy device was closing the socket immediately without sending any data to be parsed so the promise was never resolved or rejected i.e. effectively deadlocking i.e. endless `await telnetClinet.connect()`

This PR fixes just `connect` method but probably other methods (send, exec, etc) needs to be fixed too.

Generally the problem comes because the underlying socket API is event based and doesn't go well with promises. Another problem comes due lack of control to socket.timeout i.e. we can't cancel it. In overall error handling is really messy and unstable. I did my best with this patch to improve but probably will be better to rewrite everything in a better way.
