### PR TITLE
keep the call style same

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -213,8 +213,8 @@ module.exports = class Telnet extends events.EventEmitter {
         this.sendTimeout = opts.timeout || this.sendTimeout
         this.maxBufferLength = opts.maxBufferLength || this.maxBufferLength
         this.waitfor = (opts.waitfor ? (opts.waitfor instanceof RegExp ? opts.waitfor : RegExp(opts.waitfor)) : false);
-
       }
+      
       data += this.ors
 
       if (this.socket.writable) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -214,8 +214,8 @@ module.exports = class Telnet extends events.EventEmitter {
         this.maxBufferLength = opts.maxBufferLength || this.maxBufferLength
         this.waitfor = (opts.waitfor ? (opts.waitfor instanceof RegExp ? opts.waitfor : RegExp(opts.waitfor)) : false);
 
-        data += this.ors
       }
+      data += this.ors
 
       if (this.socket.writable) {
         this.socket.write(data, () => {


### PR DESCRIPTION
for now,we must provide a object as the second parameter in the "send" function,which is different with "exec" function.besides,the second pararmeter can be optional.