### PR TITLE
Fix `stripShellPrompt`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -220,7 +220,7 @@ module.exports = class Telnet extends events.EventEmitter {
         this.maxBufferLength = opts.maxBufferLength || this.maxBufferLength
         this.waitfor = (opts.waitfor ? (opts.waitfor instanceof RegExp ? opts.waitfor : RegExp(opts.waitfor)) : false);
       }
-      
+
       data += this.ors
 
       if (this.socket.writable) {
@@ -352,35 +352,26 @@ module.exports = class Telnet extends events.EventEmitter {
         return
       }
 
-      this.response = this.inputBuffer.split(this.irs)
-      this.promptSameLine = false
-
-      for (let i = 0; i < this.response.length; i++) {
-        if (utils.search(this.response[i], this.pageSeparator) !== -1) {
-          this.response[i] = this.response[i].replace(this.pageSeparator, '')
-
-          if (this.response[i].length === 0) this.response.splice(i, 1)
+      let response = this.inputBuffer.split(this.irs)
+      for (let i = response.length - 1; i--; ) {
+        if (utils.search(response[i], this.pageSeparator) !== -1) {
+          response[i] = response[i].replace(this.pageSeparator, '')
+          if (response[i].length === 0)
+            response.splice(i, 1)
         }
-        else if (this.response[i].indexOf(this.shellPrompt) !== -1)
-          this.promptSameLine = true
       }
 
-      if (this.echoLines === 1) this.response.shift()
-      else if (this.echoLines > 1) this.response.splice(0, this.echoLines)
+      if (this.echoLines === 1) response.shift()
+      else if (this.echoLines > 1) response.splice(0, this.echoLines)
 
       /* remove prompt */
       if (this.stripShellPrompt) {
-        if (this.promptSameLine) {
-          if(this.response[this.response.length - 1])
-            this.response[this.response.length - 1] =
-              this.response[this.response.length - 1].replace(this.shellPrompt, '')
-        }
-        else {
-          this.response.pop()
-          /* add a blank line so that command output maintains the trailing new line */
-          this.response.push('')
-        }
+        const idx = response.length - 1;
+        response[idx] = utils.search(response[idx], this.shellPrompt)
+          ? response[idx].replace(this.shellPrompt, '');
+          : '';
       }
+      this.response = response;
 
       this.emit('responseready')
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -353,7 +353,7 @@ module.exports = class Telnet extends events.EventEmitter {
       }
 
       let response = this.inputBuffer.split(this.irs)
-      for (let i = response.length - 1; i--; ) {
+      for (let i = response.length - 1; i >= 0; --i) {
         if (utils.search(response[i], this.pageSeparator) !== -1) {
           response[i] = response[i].replace(this.pageSeparator, '')
           if (response[i].length === 0)
@@ -367,7 +367,7 @@ module.exports = class Telnet extends events.EventEmitter {
       /* remove prompt */
       if (this.stripShellPrompt) {
         const idx = response.length - 1;
-        response[idx] = utils.search(response[idx], this.shellPrompt)
+        response[idx] = utils.search(response[idx], this.shellPrompt) > -1
           ? response[idx].replace(this.shellPrompt, '')
           : '';
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -368,7 +368,7 @@ module.exports = class Telnet extends events.EventEmitter {
       if (this.stripShellPrompt) {
         const idx = response.length - 1;
         response[idx] = utils.search(response[idx], this.shellPrompt)
-          ? response[idx].replace(this.shellPrompt, '');
+          ? response[idx].replace(this.shellPrompt, '')
           : '';
       }
       this.response = response;

--- a/test/011_dynamic_shellprompt.js
+++ b/test/011_dynamic_shellprompt.js
@@ -1,4 +1,4 @@
-var telnet = process.env.NODETELNETCLIENT_COV 
+var telnet = process.env.NODETELNETCLIENT_COV
   ? require('../lib-cov/index')
   : require('../lib/index')
 var nodeunit = require('nodeunit')
@@ -18,7 +18,7 @@ exports['dynamic_shellprompt'] = nodeunit.testCase({
         c.write(new Buffer("[prompt2]", 'ascii'))
       })
     })
-    
+
     srv.listen(2323, function() {
       callback()
     })
@@ -36,7 +36,7 @@ exports['dynamic_shellprompt'] = nodeunit.testCase({
     var params = {
       host: '127.0.0.1',
       port: 2323,
-      shellPrompt: /(>|])/,
+      shellPrompt: /[[<]\w+[>\]]/,
       timeout: 1500
     }
 
@@ -48,7 +48,7 @@ exports['dynamic_shellprompt'] = nodeunit.testCase({
         test.done()
       })
     })
-    
+
     connection.connect(params)
   },
 })


### PR DESCRIPTION
## Thesis
When `stripShellPrompt` was enabled, it was using `indexOf` rather than `utils.search`, so the regex test would fail.  This mean the last response chunk was always popped, regardless of whatever prefix may have been in the last response.

Because I'm fixing `indexOf`, it means that in order for `shellPrompt` to be replaced, it needs to be more precise to be stripped as intended.  That means the `011_dynamic_shellprompt` also needs to be updated.

min repro:
**runner**
```
const fs = require('fs');
const Telnet = require('telnet-client')
let tnet = new Telnet();

async function run() {
  const config = require('./connection.config.js');
  await tnet.connect(config);
  let res = await tnet.exec('uptime');
  console.log(`exec('uptime'):\n${res}`);
}

run();
```

**connection.config.js**
```
module.exports = {
  "port": 5000,
  "host": "freechess.org",
  "shellPrompt": /^fics% $/m,
  "timeout": 4000,  
  echoLines: 0,
  passwordPrompt: /Press return to enter the server as "\w+":/,
  username: "guest",
  password: "",
}
```


**Before:**
```
exec('uptime'):
FICS 1.25.20: compiled on Aug  9 2013 at 09:29:48
The server has been up since Thu Aug 30, 11:13 EDT 2018.
(Up for 598 days, 14 hrs, 58 mins)

There are currently 379 players, with a high of 1519 since last restart.
There are currently 82 games, with a high of 540 since last restart.
```

**After:**
```
exec('uptime'):
FICS 1.25.20: compiled on Aug  9 2013 at 09:29:48
The server has been up since Thu Aug 30, 11:13 EDT 2018.
(Up for 598 days, 14 hrs, 57 mins)

There are currently 377 players, with a high of 1519 since last restart.
There are currently 78 games, with a high of 540 since last restart.

Player limit: 3990 users (+ 10 admins)
Unregistered user restriction at 3950 users.
```

## Another bug
There was another subtle bug on line `362`.  calling `splice` while iterating (and incrementing `i`) will skip over the next item.  So altering logic to iterate backwards.

## Extra credit
In the process I'm modifying the code a bit.  Ditching the `pop/push('')` for inline replacement and a ternary.
