### PR TITLE
Fixed type of shellPrompt option

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -8,7 +8,7 @@ declare interface ConnectOptions {
     localAddress?: string;
     socketConnectOptions?: SocketConnectOpts;
     timeout?: number;
-    shellPrompt?: string;
+    shellPrompt?: string|RegExp;
     loginPrompt?: string|RegExp;
     passwordPrompt?: string|RegExp;
     failedLoginMatch?: string|RegExp;


### PR DESCRIPTION
I noticed that when using typescript to consum the package, the type of the `shellPrompt`-option was tied to `string` without `RegExp`. That's what this PR resolves.