### PR TITLE
fix register event handler sendHandler too later issue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -224,38 +224,43 @@ module.exports = class Telnet extends events.EventEmitter {
       data += this.ors
 
       if (this.socket.writable) {
-        this.socket.write(data, () => {
-          let response = ''
-          this.state = 'standby'
+        this.on('data', sendHandler);
 
-          this.on('data', sendHandler)
+        let response = '';
+        try
+        {
+          this.socket.write(data, () => {
+            this.state = 'standby'
+            if (!this.waitfor || !opts) {
+              setTimeout(() => {
+                if (response === '') {
+                    this.removeListener('data', sendHandler)
+                    reject(new Error('response not received'))
+                    return
+                }
 
-          if (!this.waitfor || !opts) {
-            setTimeout(() => {
-              if (response === '') {
-                  this.removeListener('data', sendHandler)
-                  reject(new Error('response not received'))
-                  return
-              }
-
-              this.removeListener('data', sendHandler)
-              resolve(response)
-            }, this.sendTimeout)
-          }
-
-          const self = this
-
-          function sendHandler(data) {
-            response += data.toString()
-
-            if (self.waitfor) {
-              if (!self.waitfor.test(response)) return
-
-              self.removeListener('data', sendHandler)
-              resolve(response)
+                this.removeListener('data', sendHandler)
+                resolve(response)
+              }, this.sendTimeout)
             }
+          });
+        }
+        catch(e)
+        {
+          this.removeListener('data', sendHandler);
+          reject(new Error('send data failed'));
+        }
+        const self = this
+        function sendHandler(data) {
+          response += data.toString()
+
+          if (self.waitfor) {
+            if (!self.waitfor.test(response)) return
+
+            self.removeListener('data', sendHandler)
+            resolve(response)
           }
-        })
+        }
       } else {
         reject(new Error('socket not writable'))
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -218,15 +218,14 @@ module.exports = class Telnet extends events.EventEmitter {
         this.ors = opts.ors || this.ors
         this.sendTimeout = opts.timeout || this.sendTimeout
         this.maxBufferLength = opts.maxBufferLength || this.maxBufferLength
-        this.waitfor = (opts.waitfor ? (opts.waitfor instanceof RegExp ? opts.waitfor : RegExp(opts.waitfor)) : false);
+        this.waitfor = (opts.waitfor ? (opts.waitfor instanceof RegExp ? opts.waitfor : RegExp(opts.waitfor)) : false)
       }
 
       data += this.ors
 
       if (this.socket.writable) {
-        this.on('data', sendHandler);
-
-        let response = '';
+        this.on('data', sendHandler)
+        let response = ''
         try
         {
           this.socket.write(data, () => {
@@ -243,12 +242,12 @@ module.exports = class Telnet extends events.EventEmitter {
                 resolve(response)
               }, this.sendTimeout)
             }
-          });
+          })
         }
         catch(e)
         {
-          this.removeListener('data', sendHandler);
-          reject(new Error('send data failed'));
+          this.removeListener('data', sendHandler)
+          reject(new Error('send data failed'))
         }
         const self = this
         function sendHandler(data) {


### PR DESCRIPTION
The following send function register event handler this.on('data', sendHandler) too later, sometimes if telnet server send response quickly enough, sendHandler will not be triggered because the response come in before event handler registered, , causing high lever locked if we use waitfor parameter. I have commit a fix for this issue, the fix works perfect in my testing.

send(data, opts, callback) {
if (opts && opts instanceof Function) callback = opts

return new Promise((resolve, reject) => {
  if (opts && opts instanceof Object) {
    this.ors = opts.ors || this.ors
    this.sendTimeout = opts.timeout || this.sendTimeout
    this.maxBufferLength = opts.maxBufferLength || this.maxBufferLength
    this.waitfor = (opts.waitfor ? (opts.waitfor instanceof RegExp ? opts.waitfor : RegExp(opts.waitfor)) : false);
  }

  data += this.ors

  if (this.socket.writable) {
    this.socket.write(data, () => {
      let response = ''
      this.state = 'standby'

      this.on('data', sendHandler)

      if (!this.waitfor || !opts) {
        setTimeout(() => {
          if (response === '') {
              this.removeListener('data', sendHandler)
              reject(new Error('response not received'))
              return
          }

          this.removeListener('data', sendHandler)
          resolve(response)
        }, this.sendTimeout)
      }

      const self = this

      function sendHandler(data) {
        response += data.toString()

        if (self.waitfor) {
          if (!self.waitfor.test(response)) return

          self.removeListener('data', sendHandler)
          resolve(response)
        }
      }
    })
  } else {
    reject(new Error('socket not writable'))
  }

}).asCallback(callback)
}