### PR TITLE
Do not duplicate data on .shell write

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -440,6 +440,8 @@ class Stream extends Duplex {
     if (!this.source.writable) {
       cb(new Error('socket not writable'))
     }
+
+    this.source.write(data, encoding, cb)
   }
 
   _read() {}

--- a/lib/index.js
+++ b/lib/index.js
@@ -440,11 +440,6 @@ class Stream extends Duplex {
     if (!this.source.writable) {
       cb(new Error('socket not writable'))
     }
-
-    this.source.write(data, encoding, () => {
-      this.push(data)
-      cb()
-    })
   }
 
   _read() {}


### PR DESCRIPTION
Remove unnecessary codes to solve the problem of repeated characters when typing quickly.