### PR TITLE
Remove the data listener when using waitFor as regexp

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -376,7 +376,7 @@ export class Telnet extends EventEmitter {
 
           if (this.opts.waitFor instanceof RegExp) {
             if (this.opts.waitFor.test(response)) {
-              this.removeListener('data', sendHandler)
+              this.socket.removeListener('data', sendHandler)
               resolve(response)
             }
           }


### PR DESCRIPTION
This fixes a issue were event listeners were not removed when using a regexp based waitFor