### PR TITLE
TypeScript: getSocket(), corrected return Types, resolves #213

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export class Telnet extends EventEmitter {
   private opts = Object.assign({}, defaultOptions)
   private pendingData: (string | null)[] = []
   private response: string[] = undefined
-  private socket: Socket
+  private socket: Socket | null = null
   private state: TelnetState = null
 
   constructor() {
@@ -415,7 +415,7 @@ export class Telnet extends EventEmitter {
     }), callback)
   }
 
-  getSocket(): Socket {
+  getSocket(): Socket | null {
     return this.socket
   }
 


### PR DESCRIPTION
Possible solution for #213:

as the given `tsconfig.json` does not have `"strictNullChecks": true` active, the result of your `getSocket()` was either the initialized `this.socket` object, or `undefined`. The return Type was still `Socket`, so TypeScript assumed a valid and initialized Socket object, what for instance broke my code.

This small fix inside the PR solves this issue by making the `this.socket` object either `Socket | null`.

Now it is possible in normal TS code to check for `null` and get an always working Socket object.

If this repo would turn on the strict mode of TS, the result would be lots of warnings 😺. May be a future project?
So, at least, nothing too fancy for now, but a fix for the kind of issues I had.