### PR TITLE
make sendTimeout and waitFor work together

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ export interface SendOptions {
   waitFor?: string | RegExp | false;
   /** @deprecated */
   waitfor?: string | RegExp | false;
-  sendTimeout: number;
+  sendTimeout?: number;
 }
 
 export interface ConnectOptions extends SendOptions {


### PR DESCRIPTION
Hello!

- The sendTimeout property is never used in the send method. this property must be taken by modifying the SendOptions and ConnectOptions interfaces

- I think that it is also necessary to give the possibility to the two properties waitFor and sendTimeout to work together.

The question is that what happens if send never manages to match waitFor ? In this case I think it is necessary that sendTimeout takes over and terminates the execution