### PR TITLE
Fix sendTimeout option of send command.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -388,7 +388,7 @@ export class Telnet extends EventEmitter {
 
         try {
           this.socket.write(data, () => {
-            if (!this.opts.sendTimeout) {
+            if (this.opts.sendTimeout) {
               sendTimer = setTimeout(() => {
                 sendTimer = undefined
 


### PR DESCRIPTION
Hello.
The sendTimeout option of the send ( and write ) command doesn't seem to work now.
When the sendTimeout option is set, the if statement that sets it becomes false.