### PR TITLE
fix: ExecOptions types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,13 +9,13 @@ export type EscapeHandler = (escapeSequence: string) => string | null
 export interface ExecOptions {
   echoLines?: number;
   execTimeout?: number;
-  failedLoginMatch?: string;
+  failedLoginMatch?: string | RegExp;
   irs?: string;
-  loginPrompt?: string;
+  loginPrompt?: string | RegExp;
   maxBufferLength?: number;
   newlineReplace?: string;
   ors?: string;
-  shellPrompt?: string;
+  shellPrompt?: string | RegExp;
   stripControls?: boolean;
   timeout?: number;
 }


### PR DESCRIPTION
Some ExecOptions properties types is different from SendOptions. E.g. `shellPrompt` is `string | Regex | undefined` in SendOptions, bun just `string | undefined` in ExecOptions.