### PR TITLE
Added Support Logon Disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ Telnet client will then basically act like a simple TCP client. Defaults to true
 * `maxEndWait`: The maximum time, in milliseconds, to wait for a callback from `socket.end(…)` after calling `end()`. Defaults to 250 milliseconds.
 * `encoding`: _(Experimental)_ The telnet protocol is designed mainly for 7-bit ASCII characters, and a default encoding used is `'ascii'`. You can attempt to use other encodings, however, such as `'utf8'` and `'latin1'`. Since the character values 0xF0-0xFF are used for telnet commands, not all characters for many encodings can be properly conveyed. `'utf8'` can work, however, for the roughly 64K characters in Unicode Basic Multilingual Plane (BMP).
 
+* `disableLogon`: If set to `true`, the library will not try to login into to the host automatically. This is set to `false` by default. 
+
 Resolves once the connection is ready (analogous to the ```ready``` event).
 Rejects if the timeout is hit.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6056,7 +6056,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -6753,7 +6754,8 @@
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
       "integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -6801,7 +6803,8 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-0.7.2.tgz",
       "integrity": "sha512-LOIfGx5sZZ5FwM1shr2GlYAWV9Omdi+1/3byuVagvQNoGUuU0iHhp7AfjA1uR+4dJ4Isfb4+FwBJgQajIw9iAg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-es": {
       "version": "3.0.1",
@@ -6918,13 +6921,15 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
       "integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-standard": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
       "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ export interface ConnectOptions extends SendOptions {
   terminalHeight?: number;
   terminalWidth?: number;
   username?: string;
-  disableLogon: boolean;
+  disableLogon?: boolean;
 }
 
 const defaultOptions: ConnectOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ export interface ConnectOptions extends SendOptions {
   terminalHeight?: number;
   terminalWidth?: number;
   username?: string;
+  disableLogon: boolean;
 }
 
 const defaultOptions: ConnectOptions = {
@@ -88,7 +89,8 @@ const defaultOptions: ConnectOptions = {
   stripShellPrompt: true,
   timeout: 2000,
   username: 'root',
-  waitFor: false
+  waitFor: false,
+  disableLogon: false
 }
 
 Object.freeze(defaultOptions)
@@ -542,7 +544,7 @@ export class Telnet extends EventEmitter {
   }
 
   private login(handle: string): void {
-    if ((handle === 'username' || handle === 'password') && this.socket.writable) {
+    if ((handle === 'username' || handle === 'password') && this.socket.writable && !this.opts.disableLogon) {
       this.socket.write((this.opts as any)[handle] + this.opts.ors, () => {
         this.state = 'getprompt'
       })


### PR DESCRIPTION
I have a use case where I am connected through a proxy (console server) which has authentication to a secondary host behind it. If that secondary device (router/swtich/etc) has login/password prompts that are written the library tries to write the console server login credentials to the device. Therefore I needed to add an option to ignore all login prompts but to still connect. 

Originally I tried to just pass nonsense as the login/password prompts but the connection would fail. Therefore I added the disableLogon flag.

Instead of changing all the logic that calls the login function I just added a check for the flag when it is called. When set to true the library will just return the login function. 

Other than this unique use case this is a great library.  